### PR TITLE
Dev/snopt76

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(Eigen3 REQUIRED)
 ## from whether the environmental variable is set in the ~/.bashrc, e.g.
 ## export IPOPT_DIR=/home/path/to/ipopt/Ipopt-3.12.4
 ## export SNOPT_DIR=/home/path/to/snopt/snopt_lib
+## for compatibility with SNOPT 7.6. please make sure to set the variable
+## export SNOPT76 = true
 if(NOT DEFINED ENV{IPOPT_DIR})
   message(STATUS "IPOPT_DIR not set. Not compiling for IPOPT")
 else()
@@ -25,9 +27,13 @@ if(NOT DEFINED ENV{SNOPT_DIR})
   message(STATUS "SNOPT_DIR not set. Not compiling for SNOPT")
 else()
   message(STATUS "SNOPT_DIR set. Compiling with SNOPT.")
+  if($ENV{SNOPT76})
+    message(STATUS "SNOPT76 version detected")
+  endif()
   set(SNOPT_INCLUDE_DIRS $ENV{SNOPT_DIR}/include)
-  set(SNOPT_LIBRARIES $ENV{SNOPT_DIR}/lib/libsnopt7_cpp.so 
-                      $ENV{SNOPT_DIR}/lib/libsnopt7.so)
+  find_library(SNOPT_LIB1 snopt7_cpp $ENV{SNOPT_DIR}/lib)
+  find_library(SNOPT_LIB2 snopt7 $ENV{SNOPT_DIR}/lib)
+  set(SNOPT_LIBRARIES ${SNOPT_LIB1} ${SNOPT_LIB2})
   set(SNOPT_ADAPTER_LIB ifopt_snopt)
   option(SNOPT_FOUND "Build SNOPT." ON)
 endif()
@@ -74,9 +80,12 @@ endif()
 
 # compile adapter for SNOPT 
 if(SNOPT_FOUND)
+ if($ENV{SNOPT76})
+  add_library(${SNOPT_ADAPTER_LIB} src/snopt76_adapter.cc)
+ else()
   add_library(${SNOPT_ADAPTER_LIB} src/snopt_adapter.cc)
+ endif()
 endif()
-
 
 #############
 ## Testing ##

--- a/include/ifopt/solvers/snopt76_adapter.h
+++ b/include/ifopt/solvers/snopt76_adapter.h
@@ -1,0 +1,117 @@
+/******************************************************************************
+Copyright (c) 2017, Alexander W. Winkler, ETH Zurich. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of ETH ZURICH nor the names of its contributors may be
+      used to endorse or promote products derived from this software without
+      specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH ZURICH BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#ifndef IFOPT_INCLUDE_OPT_SNOPT76_ADAPTER_H_
+#define IFOPT_INCLUDE_OPT_SNOPT76_ADAPTER_H_
+
+#include <snoptProblem.hpp>
+
+#include <ifopt/problem.h>
+
+namespace opt {
+
+/**
+ * @brief Converts an optimization problem into a SNOPT76 interface.
+ *
+ * @ingroup solvers
+ *
+ * Given an optimization Problem with variables, costs and constraints, this
+ * class wraps it and makes it conform with the interface defined by SNOPT
+ * http://web.stanford.edu/group/SOL/guides/sndoc7.pdf
+ *
+ * This implements the Adapter pattern. This class should not add any
+ * functionality, but merely delegate it to the Adaptee (the Problem object).
+ */
+class SnoptAdapter : public snoptProblemA {
+public:
+  using NLPPtr  = Problem*;
+  using VectorXd = Problem::VectorXd;
+  using Jacobian = Problem::Jacobian;
+
+  /**
+   * @brief  Creates an Adapter Object around the problem to conform to the
+   * Snopt interface.
+   */
+  SnoptAdapter (Problem& nlp);
+  virtual ~SnoptAdapter () = default;
+
+  /**
+   * @brief Creates a snoptProblemA from @a nlp and solves it.
+   * @param [in/out]  nlp  The specific problem to be used and modified.
+   */
+  static void Solve(Problem& nlp);
+
+private:
+  /**
+   * @brief  Sets solver settings for Snopt.
+   *
+   * These settings include which QP solver to use, if gradients should
+   * be approximated or the provided analytical ones used, when the iterations
+   * should be terminated,...
+   *
+   * A complete list of options can be found at:
+   * https://web.stanford.edu/group/SOL/guides/sndoc7.pdf
+   */
+  static void SetOptions(SnoptAdapter&);
+
+private:
+  void Init();
+  static void ObjectiveAndConstraintFct(int   *Status, int *n,    double x[],
+                                        int   *needF,  int *neF,  double F[],
+                                        int   *needG,  int *neG,  double G[],
+                                        char     *cu,  int *lencu,
+                                        int     iu[],  int *leniu,
+                                        double  ru[],  int *lenru);
+
+  void SetVariables();
+
+  static NLPPtr nlp_; // use raw pointer as SnoptAdapter doesn't own the nlp.
+
+
+  // additional variables as Snopt76 base class doesn't have them, not really
+  // necessary but to keep the same structure of the original SnoptAdapter
+protected:
+
+  int     jacComputed = 0;
+  int     n = 0;
+  int     neF = 0;
+  int     ObjRow;
+  double  ObjAdd;
+
+  double *x, *xlow, *xupp, *xmul;
+  double *F, *Flow, *Fupp, *Fmul;
+
+  int    *xstate, *Fstate;
+
+  int     lenA, lenG, neA, neG;
+  int    *iAfun, *jAvar, *iGfun, *jGvar;
+  double *A;
+
+};
+
+} /* namespace opt */
+
+#endif /* IFOPT_INCLUDE_OPT_SNOPT76_ADAPTER_H_ */

--- a/src/snopt76_adapter.cc
+++ b/src/snopt76_adapter.cc
@@ -1,0 +1,222 @@
+/******************************************************************************
+Copyright (c) 2017, Alexander W. Winkler, ETH Zurich. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of ETH ZURICH nor the names of its contributors may be
+      used to endorse or promote products derived from this software without
+      specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH ZURICH BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#include <ifopt/solvers/snopt76_adapter.h>
+
+namespace opt {
+
+SnoptAdapter::NLPPtr SnoptAdapter::nlp_;
+
+void
+SnoptAdapter::Solve (Problem& ref)
+{
+  SnoptAdapter snopt(ref);
+  snopt.Init();
+  SetOptions(snopt);
+
+  // error codes as given in the manual.
+  int Cold = 0; // Basis = 1, Warm = 2;
+
+  // new interface for 'Solve' using SNOPT76
+  int nS = 0; // number of super-basic variables (not relevant for cold start)
+  int nInf;   // nInf : number of constraints outside of the bounds
+  double sInf;// sInf : sum of infeasibilities
+
+   int INFO  = snopt.solve(Cold, snopt.neF, snopt.n, snopt.ObjAdd,
+                     snopt.ObjRow, &SnoptAdapter::ObjectiveAndConstraintFct,
+                     snopt.iAfun, snopt.jAvar, snopt.A, snopt.neA,
+                     snopt.iGfun, snopt.jGvar, snopt.neG,
+                     snopt.xlow, snopt.xupp, snopt.Flow, snopt.Fupp,
+                     snopt.x, snopt.xstate, snopt.xmul,
+                     snopt.F, snopt.Fstate, snopt.Fmul,
+                     nS, nInf, sInf);
+
+  int EXIT = INFO - INFO%10; // change least significant digit to zero
+
+  if (EXIT != 0) {
+    std::string msg = "Snopt failed to find a solution. EXIT:" + std::to_string(EXIT) + ", INFO:" + std::to_string(INFO);
+    throw std::runtime_error(msg);
+  }
+
+  snopt.SetVariables();
+}
+
+void SnoptAdapter::SetOptions(SnoptAdapter& solver)
+{
+  // A complete list of options can be found in the snopt user guide:
+  // https://web.stanford.edu/group/SOL/guides/sndoc7.pdf
+
+  solver.setProbName( "snopt" );
+  solver.setIntParameter( "Major Print level", 1 );
+  solver.setIntParameter( "Minor Print level", 1 );
+  solver.setParameter( "Solution");
+  solver.setIntParameter( "Derivative option", 1 ); // 1 = snopt will not calculate missing derivatives
+  solver.setIntParameter( "Verify level ", 3 ); // full check on gradients, will throw error
+  solver.setIntParameter("Iterations limit", 200000);
+  solver.setRealParameter( "Major feasibility tolerance",  1.0e-3); // target nonlinear constraint violation
+  solver.setRealParameter( "Minor feasibility tolerance",  1.0e-3); // for satisfying the QP bounds
+  solver.setRealParameter( "Major optimality tolerance",   1.0e-2); // target complementarity gap
+}
+
+SnoptAdapter::SnoptAdapter (Problem& ref)
+{
+  nlp_ = &ref;
+}
+
+void
+SnoptAdapter::Init ()
+{
+  int obj_count = nlp_->HasCostTerms()? 1 : 0;
+  n     = nlp_->GetNumberOfOptimizationVariables();
+  neF   = nlp_->GetNumberOfConstraints() + obj_count;
+
+  x      = new double[n];
+  xlow   = new double[n];
+  xupp   = new double[n];
+  xmul   = new double[n];
+  xstate = new    int[n];
+
+  F      = new double[neF];
+  Flow   = new double[neF];
+  Fupp   = new double[neF];
+  Fmul   = new double[neF];
+  Fstate = new    int[neF];
+
+  // Set the upper and lower bounds.
+  // no bounds on the spline coefficients or footholds
+  auto bounds_x = nlp_->GetBoundsOnOptimizationVariables();
+  for (uint _n=0; _n<bounds_x.size(); ++_n) {
+    xlow[_n] = bounds_x.at(_n).lower_;
+    xupp[_n] = bounds_x.at(_n).upper_;
+    xstate[_n] = 0;
+  }
+
+  // bounds on the cost function if it exists
+  int c = 0;
+  if (nlp_->HasCostTerms()) {
+    Flow[c] = -1e20; Fupp[c] = 1e20; Fmul[c] = 0.0; // no bounds on cost function
+    c++;
+  }
+
+  // bounds on equality and inequality constraints
+  auto bounds_g = nlp_->GetBoundsOnConstraints();
+  for (const auto& b : bounds_g) {
+    Flow[c] = b.lower_; Fupp[c] = b.upper_; Fmul[c] = 0.0;
+    c++;
+  }
+
+  // initial values of the optimization
+  VectorXd x_all = nlp_->GetVariableValues();
+  Eigen::Map<VectorXd>(&x[0], x_all.rows()) = x_all;
+
+  ObjRow  = nlp_->HasCostTerms()? 0 : -1; // the row in user function that corresponds to the objective function
+  ObjAdd  = 0.0;                          // the constant to be added to the objective function
+
+  // no linear derivatives/just assume all are nonlinear
+  lenA = 0;
+  neA = 0;
+  iAfun = nullptr;
+  jAvar = nullptr;
+  A = nullptr;
+
+  // derivatives of nonlinear part
+  lenG  = obj_count*n + nlp_->GetJacobianOfConstraints().nonZeros();
+  iGfun = new int[lenG];
+  jGvar = new int[lenG];
+
+  // the gradient terms of the cost function
+  neG=0; // nonzero cells in jacobian of Cost Function AND Constraints
+
+  // the nonzero elements of cost function (assume all)
+  if(nlp_->HasCostTerms()) {
+    for (int var=0; var<n; ++var) {
+      iGfun[neG] = 0;
+      jGvar[neG] = var;
+      neG++;
+    }
+  }
+
+  // the nonzero elements of constraints (assume all)
+  auto jac = nlp_->GetJacobianOfConstraints();
+  for (int k=0; k<jac.outerSize(); ++k) {
+    for (Jacobian::InnerIterator it(jac,k); it; ++it) {
+      iGfun[neG] = it.row() + obj_count;
+      jGvar[neG] = it.col();
+      neG++;
+    }
+  }
+
+  // Snopt76 requires initialization
+  this->initialize("", 1); // no print_file and summary ON
+
+  // Snopt76 needs to setup the workspace
+  this->setWorkspace(neF,n,neA,neG);
+
+}
+
+void
+SnoptAdapter::ObjectiveAndConstraintFct (int* Status, int* n, double x[],
+                                         int* needF, int* neF, double F[],
+                                         int* needG, int* neG, double G[],
+                                         char* cu, int* lencu, int iu[],
+                                         int* leniu, double ru[], int* lenru)
+{
+  if ( *needF > 0 ) {
+    int i=0;
+
+    // the scalar objective function value
+    if (nlp_->HasCostTerms())
+      F[i++] = nlp_->EvaluateCostFunction(x);
+
+    // the vector of constraint values
+    VectorXd g_eig = nlp_->EvaluateConstraints(x);
+    Eigen::Map<VectorXd>(F+i, g_eig.rows()) = g_eig;
+  }
+
+
+  if ( *needG > 0 ) {
+    int i=0;
+
+    // the jacobian of the first row (cost function)
+    if (nlp_->HasCostTerms()) {
+      Eigen::VectorXd grad = nlp_->EvaluateCostFunctionGradient(x);
+      i = grad.rows();
+      Eigen::Map<VectorXd>(G, i) = grad;
+    }
+
+    // the jacobian of all the constraints
+    nlp_->EvalNonzerosOfJacobian(x, G+i);
+    nlp_->SaveCurrent();
+  }
+}
+
+void
+SnoptAdapter::SetVariables ()
+{
+  nlp_->SetVariables(x);
+}
+
+} /* namespace opt */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,10 @@ endif()
 # Solve example problem with SNOPT if installed
 if(SNOPT_FOUND)
   add_executable(snopt_test ex_test_snopt.cc)
+  if($ENV{SNOPT76})
+  	target_compile_definitions(snopt_test PRIVATE SNOPT76_ON=1)
+  endif()
+  
   target_link_libraries(snopt_test
                         ${PROJECT_NAME}
                         ${SNOPT_ADAPTER_LIB}

--- a/test/ex_test_snopt.cc
+++ b/test/ex_test_snopt.cc
@@ -26,7 +26,12 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
 
-#include <ifopt/solvers/snopt_adapter.h>
+#ifdef SNOPT76
+  #include <ifopt/solvers/snopt76_adapter.h>
+#else
+  #include <ifopt/solvers/snopt_adapter.h>
+#endif
+
 #include "ex_problem.h"
 
 using namespace opt;


### PR DESCRIPTION
New interface for SNOPT 7.6

The user should set an environmental variable to inform it is using this version, similar to the variable required for the library directory.

The new interface lives in different header and source files, the user should include the correct header. In the test/example compilation rule is shown how to do that automatically.
